### PR TITLE
fix order in public transport analysis

### DIFF
--- a/analysers/analyser_osmosis_relation_public_transport.py
+++ b/analysers/analyser_osmosis_relation_public_transport.py
@@ -511,7 +511,7 @@ SELECT
     stop_platform.member_type || stop_platform.mid AS stop_id,
     stop_platform.geom AS stop,
     ROW_NUMBER () OVER (PARTITION BY route_linestring.id ORDER BY stop_platform.morder) AS stop_order,
-    ROW_NUMBER () OVER (PARTITION BY route_linestring.id ORDER BY ST_LineLocatePoint(route_linestring.geom, stop_platform.geom)) AS projected_stop_order,
+    ROW_NUMBER () OVER (PARTITION BY route_linestring.id ORDER BY ST_LineLocatePoint(ST_OffsetCurve(route_linestring.geom, -10), stop_platform.geom) DESC) AS projected_stop_order,
     CASE
         WHEN LEAD(stop_platform.morder, 1) OVER (PARTITION BY route_linestring.id ORDER BY stop_platform.morder) IS NULL THEN 1
         ELSE 0
@@ -523,7 +523,7 @@ FROM
     WHERE
         stop_platform.mrole IN ('platform', 'platform_exit_only', 'platform_entry_only') AND
         stop_platform.member_type='N' AND
-        GeometryType(route_linestring.geom) = 'LINESTRING' AND
+        GeometryType(ST_OffsetCurve(route_linestring.geom, -10)) = 'LINESTRING' AND
         ST_LineLocatePoint(route_linestring.geom, ST_ClosestPoint(route_linestring.geom, stop_platform.geom)) NOT IN (0, 1)
 )
 """


### PR DESCRIPTION
put back the offset (to make sure the projection on the the ways is ok even if the same way is used multiple times in the relation)

Fix #1262