### PR TITLE
charging_station_FR: add support for output power tags

### DIFF
--- a/analysers/analyser_merge_charging_station_FR.py
+++ b/analysers/analyser_merge_charging_station_FR.py
@@ -99,9 +99,13 @@ with `capacity=6` can sometimes match to 3 charging station with `capacity=2`'''
                         "reservation": lambda fields: "yes" if fields["reservation_grouped"] == "true" else None,
                         "wheelchair": lambda fields: "yes" if fields["accessibilite_pmr_grouped"] == "Accessible mais non réservé PMR" else ("no" if fields["accessibilite_pmr_grouped"] == "Non accessible" else None),
                         "socket:typee": lambda fields: fields["nb_EF_grouped"] if fields["nb_EF_grouped"] != "0" else None,
+                        "socket:typee:output": lambda fields: fields["power_ef_grouped"]+" kW" if fields["power_ef_grouped"] != "0" else None,
                         "socket:type2": lambda fields: fields["nb_T2_grouped"] if fields["nb_T2_grouped"] != "0" else None,
+                        "socket:type2:output": lambda fields: fields["power_t2_grouped"]+" kW" if fields["power_t2_grouped"] != "0" else None,
                         "socket:type2_combo": lambda fields: fields["nb_combo_ccs_grouped"] if fields["nb_combo_ccs_grouped"] != "0" else None,
+                        "socket:type2_combo:output": lambda fields: fields["power_ccs_grouped"]+" kW" if fields["power_ccs_grouped"] != "0" else None,
                         "socket:chademo": lambda fields: fields["nb_chademo_grouped"] if fields["nb_chademo_grouped"] != "0" else None,
+                        "socket:chademo:output": lambda fields: fields["power_chademo_grouped"]+" kW" if fields["power_chademo_grouped"] != "0" else None,
                         "wikimedia:network": lambda fields: self.WIKIDATA_MAP.get(fields["nom_enseigne"].lower(), None) if fields["nom_enseigne"] != "0" else None,
                     },
                     text=lambda tags, fields: {"en": "{0}, {1}, {2}".format(fields["nom_station"], fields["adresse_station"], fields["observations"] if fields["observations"] != "null" else "-")})))


### PR DESCRIPTION
This will use the newly aggregated data from https://github.com/Jungle-Bus/ref-EU-EVSE/pull/15.

We may want to also edit the `trap` text:
The data published is the output of one point of delivery which may have multiple sockets, so it is assumed that a charger able to output 100 kW on a combo-CCS socket will be able to "max out" a Type 2 socket rated at 43 kW (in my experience that's the case). In this scenario the `socket:type2:output` is "deduced" and we may inform the users to check it.

There's also a related conversation on this topic with @nlehuby here > https://github.com/Jungle-Bus/ref-EU-EVSE/pull/14
