### PR TITLE
Plugin/TagFix_Maxspeed_AT

### DIFF
--- a/osmose_config.py
+++ b/osmose_config.py
@@ -1818,15 +1818,15 @@ de_state("thueringen", 62366, "DE-TH")
 
 at_state = gen_country('europe', 'austria', download_repo=OSMFR, language='de', proj=32633)
 
-at_state("niederosterreich", 77189, "AT-3")
-at_state("burgenland", 76909, "AT-1")
-at_state("karnten", 52345, "AT-2")
-at_state("oberosterreich", 102303, "AT-4")
-at_state("salzburg", 86539, "AT-5")
-at_state("steiermark", 35183, "AT-6")
-at_state("tirol", 52343, "AT-7")
-at_state("wien", 109166, "AT-9")
-at_state("vorarlberg", 74942, "AT-8")
+at_state("niederosterreich", 77189, "AT-NOE")
+at_state("burgenland", 76909, "AT-B")
+at_state("karnten", 52345, "AT-K")
+at_state("oberosterreich", 102303, "AT-OOE")
+at_state("salzburg", 86539, "AT-S")
+at_state("steiermark", 35183, "AT-ST")
+at_state("tirol", 52343, "AT-T")
+at_state("wien", 109166, "AT-W")
+at_state("vorarlberg", 74942, "AT-V")
 
 #########################################################################
 

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -1818,15 +1818,15 @@ de_state("thueringen", 62366, "DE-TH")
 
 at_state = gen_country('europe', 'austria', download_repo=OSMFR, language='de', proj=32633)
 
-at_state("niederoesterreich", 77189, "AT-NOE")
-at_state("burgenland", 76909, "AT-B")
-at_state("kaernten", 52345, "AT-K")
-at_state("oberoesterreich", 102303, "AT-OOE")
-at_state("salzburg", 86539, "AT-S")
-at_state("steiermark", 35183, "AT-ST")
-at_state("tirol", 52343, "AT-T")
-at_state("wien", 109166, "AT-W")
-at_state("vorarlberg", 74942, "AT-V")
+at_state("niederosterreich", 77189, "AT-3")
+at_state("burgenland", 76909, "AT-1")
+at_state("karnten", 52345, "AT-2")
+at_state("oberosterreich", 102303, "AT-4")
+at_state("salzburg", 86539, "AT-5")
+at_state("steiermark", 35183, "AT-6")
+at_state("tirol", 52343, "AT-7")
+at_state("wien", 109166, "AT-9")
+at_state("vorarlberg", 74942, "AT-8")
 
 #########################################################################
 

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -1818,10 +1818,10 @@ de_state("thueringen", 62366, "DE-TH")
 
 at_state = gen_country('europe', 'austria', download_repo=OSMFR, language='de', proj=32633)
 
-at_state("niederosterreich", 77189, "AT-NOE")
+at_state("niederoesterreich", 77189, "AT-NOE")
 at_state("burgenland", 76909, "AT-B")
-at_state("karnten", 52345, "AT-K")
-at_state("oberosterreich", 102303, "AT-OOE")
+at_state("kaernten", 52345, "AT-K")
+at_state("oberoesterreich", 102303, "AT-OOE")
 at_state("salzburg", 86539, "AT-S")
 at_state("steiermark", 35183, "AT-ST")
 at_state("tirol", 52343, "AT-T")

--- a/plugins/TagFix_Maxspeed_AT.py
+++ b/plugins/TagFix_Maxspeed_AT.py
@@ -66,7 +66,7 @@ Always check `highway`, all other tags related to speed and verify on the ground
 '''Set `maxspeed` as appropriate and set speed limit type in either `maxspeed:type` or `source:maxspeed`. For a list of values, 
 see [Implicit maxspeed values](https://wiki.openstreetmap.org/wiki/Key:maxspeed#Implicit_maxspeed_values).'''),
             trap=T_(
-'''If a speed limit type (e.g. `AT:*`) is set in `maxspeed`, do not assume it's correct!
+'''If a speed limit type (e.g. `AT:*`) is set in `maxspeed`, do not assume it is correct!
 Always check `highway`, all other tags related to speed and verify on the ground.'''),
             resource='https://wiki.openstreetmap.org/wiki/Key:maxspeed')
 
@@ -90,16 +90,17 @@ Always check `highway`, all other tags related to speed and verify on the ground
 '''The speed limit type in `maxspeed:type` or `source:maxspeed` is not valid.'''),
             fix=T_(
 '''Set the appropriate speed limit type. For a list of values,
-see [Implicit maxspeed values](https://wiki.openstreetmap.org/wiki/Key:maxspeed#Implicit_maxspeed_values)'''),
+see [Implicit maxspeed values](https://wiki.openstreetmap.org/wiki/Key:maxspeed#Implicit_maxspeed_values).'''),
             trap=T_(
-'''Do not assume any of the data present is correct!
+'''In case the speed limit type is `zone`, do not just change it to `AT:zone`, but to a more specific value.
+Do not assume any of the data present is correct!
 Always check `highway`, all other tags related to speed and verify on the ground.'''),
             resource='https://wiki.openstreetmap.org/wiki/DE:Key:maxspeed:type')
 
         self.errors[5] = self.def_class(item=3032, level=2, tags=['maxspeed'],
             title=T_('Multiple speed limit types'),
             detail=T_(
-'''`maxspeed:type` and `source:maxspeed` are both set. This may cause confusion for mappers and data consumers
+'''`maxspeed:type` and `source:maxspeed` are both set. This may confuse mappers and data consumers
 if the values are different.'''),
             fix=T_(
 '''Set either `maxspeed:type` or `source:maxspeed`. For a list of values,
@@ -136,7 +137,7 @@ Always check `highway`, all other tags related to speed and verify on the ground
         # Error: maxspeed type without maxspeed
         if not maxspeed:
             if maxspeed_type or source_maxspeed:
-                err.append({'class': 1, 'text': T_('{0} without maxspeed',
+                err.append({'class': 1, 'text': T_('`{0}` without maxspeed',
                                                    maxspeed_type if maxspeed_type else source_maxspeed)})
             return err
 

--- a/plugins/TagFix_Maxspeed_AT.py
+++ b/plugins/TagFix_Maxspeed_AT.py
@@ -51,8 +51,8 @@ class TagFix_Maxspeed_AT(Plugin):
             detail=T_(
 '''A speed limit type is given in `maxspeed:type` or `source:maxspeed`, but no speed limit is set in `maxspeed`.'''),
             fix=T_(
-'''Set `maxspeed` and `maxspeed:type` or `source:maxspeed` (but not both) as appropriate.
-For a list of values, see table 'valid_maxspeed_types' in the source code below.'''),
+'''Set `maxspeed` and either `maxspeed:type` or `source:maxspeed` as appropriate. For a list of values, 
+see [Implicit maxspeed values](https://wiki.openstreetmap.org/wiki/Key:maxspeed#Implicit_maxspeed_values).'''),
             trap=T_(
 '''Do not just add a `maxspeed` value suitable for the type. The type may be incorrect too!
 Always check `highway`, all other tags related to speed and verify on the ground.'''),
@@ -63,8 +63,8 @@ Always check `highway`, all other tags related to speed and verify on the ground
             detail=T_(
 '''The speed limit in `maxspeed` must be either numeric or `walk`. Do not specify a unit, km/h is the default.'''),
             fix=T_(
-'''Set `maxspeed` as appropriate and set speed limit type in `maxspeed:type` or `source:maxspeed` (but not both).
-For a list of values, see table 'valid_maxspeed_types' in the source code below.'''),
+'''Set `maxspeed` as appropriate and set speed limit type in either `maxspeed:type` or `source:maxspeed`. For a list of values, 
+see [Implicit maxspeed values](https://wiki.openstreetmap.org/wiki/Key:maxspeed#Implicit_maxspeed_values).'''),
             trap=T_(
 '''If a speed limit type (e.g. `AT:*`) is set in `maxspeed`, do not assume it's correct!
 Always check `highway`, all other tags related to speed and verify on the ground.'''),
@@ -90,7 +90,7 @@ Always check `highway`, all other tags related to speed and verify on the ground
 '''The speed limit type in `maxspeed:type` or `source:maxspeed` is not valid.'''),
             fix=T_(
 '''Set the appropriate speed limit type. For a list of values,
-see the table 'valid_maxspeed_types' in the source code below.'''),
+see [Implicit maxspeed values](https://wiki.openstreetmap.org/wiki/Key:maxspeed#Implicit_maxspeed_values)'''),
             trap=T_(
 '''Do not assume any of the data present is correct!
 Always check `highway`, all other tags related to speed and verify on the ground.'''),
@@ -99,11 +99,11 @@ Always check `highway`, all other tags related to speed and verify on the ground
         self.errors[5] = self.def_class(item=3032, level=2, tags=['maxspeed'],
             title=T_('Multiple speed limit types'),
             detail=T_(
-'''`maxspeed:type` and `source:maxspeed` are both set. This may cause confusion for mappers and data consumers,
-especially if the values are different.'''),
+'''`maxspeed:type` and `source:maxspeed` are both set. This may cause confusion for mappers and data consumers
+if the values are different.'''),
             fix=T_(
-'''Set either `maxspeed:type` or `source:maxspeed` (but not both). For a list of values,
-see table 'valid_maxspeed_types' in the source code below.'''),
+'''Set either `maxspeed:type` or `source:maxspeed`. For a list of values,
+see [Implicit maxspeed values](https://wiki.openstreetmap.org/wiki/Key:maxspeed#Implicit_maxspeed_values).'''),
             trap=T_(
 '''Do not assume any of the data present is correct!
 Always check `highway`, all other tags related to speed and verify on the ground.'''),
@@ -114,8 +114,8 @@ Always check `highway`, all other tags related to speed and verify on the ground
             detail=T_(
 '''The speed limit in `maxspeed` is not consistent with the speed limit type in `maxspeed:type` or `source:maxspeed`.'''),
             fix=T_(
-'''Set `maxspeed` and/or `maxspeed:type`/`source:maxspeed` (but not both) as appropriate. For a list of values,
-see table 'valid_maxspeed_types' in the source code below.'''),
+'''Adjust `maxspeed`, `maxspeed:type` or `source:maxspeed` as appropriate. For a list of values,
+see [Implicit maxspeed values](https://wiki.openstreetmap.org/wiki/Key:maxspeed#Implicit_maxspeed_values).'''),
             trap=T_(
 '''Do not assume any of the data present is correct!
 Always check `highway`, all other tags related to speed and verify on the ground.'''),

--- a/plugins/TagFix_Maxspeed_AT.py
+++ b/plugins/TagFix_Maxspeed_AT.py
@@ -199,11 +199,7 @@ class Test(TestPluginCommon):
         plugin = TagFix_Maxspeed_AT(None)
         plugin.init(None)
 
-        # No error if not in Austria
-        assert not plugin.way(None, {'highway': 'residential', 'maxspeed_type': 'dont know',
-                              'source:maxspeed': 'unknown'}, None)
-
-        # No error if in Austria but not a highway
+        # No error if not a highway
         assert not plugin.way(None, {'maxspeed_type': 'dont know', 'source:maxspeed': 'unknown'}, None)
 
         # No error if valid
@@ -223,32 +219,32 @@ class Test(TestPluginCommon):
                                                'source:maxspeed': 'read it in the news'}, None)
 
         # Error when maxspeed type without maxspeed
-        assert self.check_err(plugin.way(None, {'highway': 'secondary', 'maxspeed:type': 'sign'}, None))
+        self.check_err(plugin.way(None, {'highway': 'secondary', 'maxspeed:type': 'sign'}, None))
 
-        assert self.check_err(plugin.way(None, {'highway': 'secondary', 'source:maxspeed': 'sign'}, None))
+        self.check_err(plugin.way(None, {'highway': 'secondary', 'source:maxspeed': 'sign'}, None))
 
         # Error when maxspeed not numeric or walk
-        assert self.check_err(plugin.way(None, {'highway': 'tertiary', 'maxspeed': 'fast'}, None))
+        self.check_err(plugin.way(None, {'highway': 'tertiary', 'maxspeed': 'fast'}, None))
 
         # Error when maxspeed too low
-        assert self.check_err(plugin.way(None, {'highway': 'residential', 'maxspeed': '5'}, None))
+        self.check_err(plugin.way(None, {'highway': 'residential', 'maxspeed': '5'}, None))
 
         # Error when invalid speed limit type
-        assert self.check_err(plugin.way(None, {'highway': 'residential', 'maxspeed': '50',
-                                                          'source:maxspeed': 'AT:city'}, None))
+        self.check_err(plugin.way(None, {'highway': 'residential', 'maxspeed': '50',
+                                                   'source:maxspeed': 'AT:city'}, None))
 
-        assert self.check_err(plugin.way(None, {'highway': 'secondary', 'maxspeed': '70', 'maxspeed:type': 'yes'}, None))
+        self.check_err(plugin.way(None, {'highway': 'secondary', 'maxspeed': '70', 'maxspeed:type': 'yes'}, None))
 
         # Error when speed limit type duplication
-        assert self.check_err(plugin.way(None, {'highway': 'unclassified', 'maxspeed': '100',
-                                                          'maxspeed:type': 'AT:zone40', 'source:maxspeed': 'AT:rural'}, None))
+        self.check_err(plugin.way(None, {'highway': 'unclassified', 'maxspeed': '100',
+                                                   'maxspeed:type': 'AT:zone40', 'source:maxspeed': 'AT:rural'}, None))
 
-        assert self.check_err(plugin.way(None, {'highway': 'unclassified', 'maxspeed': '100',
-                                                          'maxspeed:type': 'AT:rural', 'source:maxspeed': 'AT:urban'}, None))
+        self.check_err(plugin.way(None, {'highway': 'unclassified', 'maxspeed': '100',
+                                                   'maxspeed:type': 'AT:rural', 'source:maxspeed': 'AT:urban'}, None))
 
         # Error when speed and type mismatch
-        assert self.check_err(plugin.way(None, {'highway': 'secondary', 'maxspeed': '70',
-                                                          'maxspeed:type': 'AT:city_limit30'}, None))
+        self.check_err(plugin.way(None, {'highway': 'secondary', 'maxspeed': '70',
+                                                   'maxspeed:type': 'AT:city_limit30'}, None))
 
-        assert self.check_err(plugin.way(None, {'highway': 'tertiary', 'maxspeed': '50',
-                                                          'source:maxspeed': 'AT:rural'}, None))
+        self.check_err(plugin.way(None, {'highway': 'tertiary', 'maxspeed': '50',
+                                                   'source:maxspeed': 'AT:rural'}, None))

--- a/plugins/TagFix_Maxspeed_AT.py
+++ b/plugins/TagFix_Maxspeed_AT.py
@@ -38,13 +38,9 @@ class TagFix_Maxspeed_AT(Plugin):
         'AT:zone15': '15', 'AT:zone20': '20', 'AT:zone30': '30', 'AT:zone40': '40', 'AT:zone50': '50', 'AT:zone70': '70',
         'AT:shared_zone20': '20', 'AT:shared_zone30': '30',
         'AT:bicycle_road': '30',
-        # Under discussion, different spelling
+        # Alternatives
         'AT:zone:20': '20', 'AT:zone:30': '30', 'AT:zone:40': '40', 'AT:zone:50': '50',
-        # Under discussion, interim usage, to be replaced
-        'AT:Wohnstraße': 'walk',
-        'AT:Begegnungszone:20': '20', 'AT:Begegnungszone:30': '30', 'AT:shared_space': '20',
-        # Under discussion, probably obsolete
-        'zone': '', 'AT:zone': ''
+        'AT:zone': ''
     }
 
     def init(self, logger):
@@ -183,7 +179,7 @@ Always check `highway`, all other tags related to speed and verify on the ground
 
         # Error: maxspeed type doesn't match maxspeed
         # except for types covered in TagFix_Maxspeed plugin and types without specific speed
-        if valid_type and valid_type not in {'AT:motorway', 'AT:trunk', 'AT:rural', 'AT:urban', 'sign', 'AT:zone', 'zone'}:
+        if valid_type and valid_type not in {'AT:motorway', 'AT:trunk', 'AT:rural', 'AT:urban', 'sign', 'AT:zone'}:
             if maxspeed != self.valid_maxspeed_types.get(valid_type):
                 err.append({'class': 6,
                             'text': T_('maxspeed and type mismatch: `{0}`<>`{1}`', maxspeed, valid_type)})

--- a/plugins/TagFix_Maxspeed_AT.py
+++ b/plugins/TagFix_Maxspeed_AT.py
@@ -75,10 +75,10 @@ Always check `highway`, all other tags related to speed and verify on the ground
             detail=T_(
 '''The speed limit in `maxspeed` is very low and no type is given in `maxspeed:type` or `source:maxspeed`.'''),
             fix=T_(
-'''For pedestrian areas and living streets (except shared zones and school roads), walking speed is the default and no
-speed limit or type should be set. If walking speed is prescribed on a sign, set `maxspeed=walk`, `maxspeed:type=sign`
-and `traffic_sign=AT:54[text]` or `traffic_sign=AT:..,54[text]`. If a speed of 5 km/h is prescribed on a sign,
-set `maxspeed=5`, `maxspeed:type=sign`.'''),
+'''For pedestrian areas and living streets (except shared zones), walking speed is the default and no
+speed limit or type should be set. If walking speed is signposted, set `maxspeed=walk`, `maxspeed:type=sign`
+and `traffic_sign=AT:54[text]` or `traffic_sign=AT:..,54[text]`. If a low speed is signposted,
+set `maxspeed` to the speed, `maxspeed:type=sign`.'''),
             trap=T_(
 '''Do not assume any of the data present is correct!
 Always check `highway`, all other tags related to speed and verify on the ground.'''),
@@ -145,11 +145,11 @@ Always check `highway`, all other tags related to speed and verify on the ground
             return {'class': 2, 'text': T_('Invalid maxspeed: `{0}`', maxspeed)}
 
         # Error: maxspeed suspiciously low, probably 'walk'; needs verification
+        # except for speeds < 5 (covered in Number.py) and if signposted
         if maxspeed.isdigit():
             maxspeed_num = int(maxspeed)
-            if maxspeed_num < 10:
-                if maxspeed_num != 5 or (maxspeed_type != 'sign' and source_maxspeed != 'sign'):
-                    return {'class': 3, 'text': T_('Low maxspeed: `{0}`', maxspeed)}
+            if (maxspeed_num > 4) and (maxspeed_num < 15) and (maxspeed_type != 'sign') and (source_maxspeed != 'sign'):
+                return {'class': 3, 'text': T_('Low maxspeed: `{0}`', maxspeed)}
 
         valid_type = None
         if maxspeed_type:

--- a/plugins/TagFix_Maxspeed_AT.py
+++ b/plugins/TagFix_Maxspeed_AT.py
@@ -89,7 +89,7 @@ Always check `highway`, all other tags related to speed and verify on the ground
             resource='https://wiki.openstreetmap.org/wiki/DE:Verkehrszeichen_in_Österreich')
 
         self.errors[4] = self.def_class(item=3091, level=2, tags=['value', 'maxspeed'],
-            title=T_('Invalid speed limit type '),
+            title=T_('Invalid speed limit type'),
             detail=T_(
 '''The speed limit type in `maxspeed:type` or `source:maxspeed` is not valid.'''),
             fix=T_(

--- a/plugins/TagFix_Maxspeed_AT.py
+++ b/plugins/TagFix_Maxspeed_AT.py
@@ -137,7 +137,7 @@ Always check `highway`, all other tags related to speed and verify on the ground
         # Error: maxspeed type without maxspeed
         if not maxspeed:
             if maxspeed_type or source_maxspeed:
-                err.append({'class': 303220, 'text': T_('`{0}` without maxspeed',
+                err.append({'class': 303220, 'text': T_('`source:maxspeed` or `maxspeed:type` = `{0}` without maxspeed',
                                                    maxspeed_type if maxspeed_type else source_maxspeed)})
             return err
 

--- a/plugins/TagFix_Maxspeed_AT.py
+++ b/plugins/TagFix_Maxspeed_AT.py
@@ -136,7 +136,8 @@ Always check `highway`, all other tags related to speed and verify on the ground
         # Error: maxspeed type without maxspeed
         if not maxspeed:
             if maxspeed_type or source_maxspeed:
-                err.append({'class': 1, 'text': T_('Speed limit type without maxspeed')})
+                err.append({'class': 1, 'text': T_('{0} without maxspeed',
+                                                   maxspeed_type if maxspeed_type else source_maxspeed)})
             return err
 
         # Error: maxspeed not numeric or 'walk'

--- a/plugins/TagFix_Maxspeed_AT.py
+++ b/plugins/TagFix_Maxspeed_AT.py
@@ -179,8 +179,8 @@ Always check `highway`, all other tags related to speed and verify on the ground
 
         # Error: maxspeed type doesn't match maxspeed
         # except for types covered in TagFix_Maxspeed plugin and types without specific speed
-        if valid_type and valid_type not in {'AT:motorway', 'AT:trunk', 'AT:rural', 'AT:urban', 'sign', 'AT:zone'}:
-            if maxspeed != self.valid_maxspeed_types.get(valid_type):
+        if valid_type and valid_type not in {'AT:motorway', 'AT:trunk', 'AT:rural', 'AT:urban'}:
+            if self.valid_maxspeed_types.get(valid_type) and (self.valid_maxspeed_types.get(valid_type) != maxspeed):
                 err.append({'class': 6,
                             'text': T_('maxspeed and type mismatch: `{0}`<>`{1}`', maxspeed, valid_type)})
 

--- a/plugins/TagFix_Maxspeed_AT.py
+++ b/plugins/TagFix_Maxspeed_AT.py
@@ -51,7 +51,7 @@ class TagFix_Maxspeed_AT(Plugin):
             detail=T_(
 '''A speed limit type is given in `maxspeed:type` or `source:maxspeed`, but no speed limit is set in `maxspeed`.'''),
             fix=T_(
-'''Set `maxspeed` and either `maxspeed:type` or `source:maxspeed` as appropriate. For a list of values, 
+'''Set `maxspeed` and either `maxspeed:type` or `source:maxspeed` as appropriate. For a list of values,
 see [Implicit maxspeed values](https://wiki.openstreetmap.org/wiki/Key:maxspeed#Implicit_maxspeed_values).'''),
             trap=T_(
 '''Do not just add a `maxspeed` value suitable for the type. The type may be incorrect too!
@@ -63,7 +63,7 @@ Always check `highway`, all other tags related to speed and verify on the ground
             detail=T_(
 '''The speed limit in `maxspeed` must be either numeric or `walk`. Do not specify a unit, km/h is the default.'''),
             fix=T_(
-'''Set `maxspeed` as appropriate and set speed limit type in either `maxspeed:type` or `source:maxspeed`. For a list of values, 
+'''Set `maxspeed` as appropriate and set speed limit type in either `maxspeed:type` or `source:maxspeed`. For a list of values,
 see [Implicit maxspeed values](https://wiki.openstreetmap.org/wiki/Key:maxspeed#Implicit_maxspeed_values).'''),
             trap=T_(
 '''If a speed limit type (e.g. `AT:*`) is set in `maxspeed`, do not assume it is correct!
@@ -245,4 +245,4 @@ class Test(TestPluginCommon):
                                                    'maxspeed:type': 'AT:city_limit30'}, None))
 
         self.check_err(plugin.way(None, {'highway': 'tertiary', 'maxspeed': '50',
-                                                   'source:maxspeed': 'AT:rural'}, None))
+                                                   'source:maxspeed': 'AT:city_limit30'}, None))

--- a/plugins/TagFix_Maxspeed_AT.py
+++ b/plugins/TagFix_Maxspeed_AT.py
@@ -46,7 +46,7 @@ class TagFix_Maxspeed_AT(Plugin):
     def init(self, logger):
         Plugin.init(self, logger)
 
-        self.errors[1] = self.def_class(item=3032, level=2, tags=['maxspeed'],
+        self.errors[303220] = self.def_class(item=3032, level=2, tags=['maxspeed'],
             title=T_('Speed limit type without speed limit'),
             detail=T_(
 '''A speed limit type is given in `maxspeed:type` or `source:maxspeed`, but no speed limit is set in `maxspeed`.'''),
@@ -58,7 +58,7 @@ see [Implicit maxspeed values](https://wiki.openstreetmap.org/wiki/Key:maxspeed#
 Always check `highway`, all other tags related to speed and verify on the ground.'''),
             resource='https://wiki.openstreetmap.org/wiki/Key:maxspeed')
 
-        self.errors[2] = self.def_class(item=3091, level=1, tags=['value', 'maxspeed'],
+        self.errors[309110] = self.def_class(item=3091, level=1, tags=['value', 'maxspeed'],
             title=T_('Invalid speed limit value'),
             detail=T_(
 '''The speed limit in `maxspeed` must be either numeric or `walk`. Do not specify a unit, km/h is the default.'''),
@@ -70,7 +70,7 @@ see [Implicit maxspeed values](https://wiki.openstreetmap.org/wiki/Key:maxspeed#
 Always check `highway`, all other tags related to speed and verify on the ground.'''),
             resource='https://wiki.openstreetmap.org/wiki/Key:maxspeed')
 
-        self.errors[3] = self.def_class(item=3091, level=2, tags=['maxspeed'],
+        self.errors[309111] = self.def_class(item=3091, level=2, tags=['maxspeed'],
             title=T_('Low speed limit value'),
             detail=T_(
 '''The speed limit in `maxspeed` is very low and no type is given in `maxspeed:type` or `source:maxspeed`.'''),
@@ -84,7 +84,7 @@ set `maxspeed` to the speed, `maxspeed:type=sign`.'''),
 Always check `highway`, all other tags related to speed and verify on the ground.'''),
             resource='https://wiki.openstreetmap.org/wiki/DE:Verkehrszeichen_in_Österreich')
 
-        self.errors[4] = self.def_class(item=3091, level=2, tags=['value', 'maxspeed'],
+        self.errors[309112] = self.def_class(item=3091, level=2, tags=['value', 'maxspeed'],
             title=T_('Invalid speed limit type'),
             detail=T_(
 '''The speed limit type in `maxspeed:type` or `source:maxspeed` is not valid.'''),
@@ -97,7 +97,7 @@ Do not assume any of the data present is correct!
 Always check `highway`, all other tags related to speed and verify on the ground.'''),
             resource='https://wiki.openstreetmap.org/wiki/DE:Key:maxspeed:type')
 
-        self.errors[5] = self.def_class(item=3032, level=2, tags=['maxspeed'],
+        self.errors[303221] = self.def_class(item=3032, level=2, tags=['maxspeed'],
             title=T_('Multiple speed limit types'),
             detail=T_(
 '''`maxspeed:type` and `source:maxspeed` are both set. This may confuse mappers and data consumers
@@ -110,7 +110,7 @@ see [Implicit maxspeed values](https://wiki.openstreetmap.org/wiki/Key:maxspeed#
 Always check `highway`, all other tags related to speed and verify on the ground.'''),
             resource='https://wiki.openstreetmap.org/wiki/DE:Key:maxspeed:type')
 
-        self.errors[6] = self.def_class(item=3032, level=1, tags=['maxspeed'],
+        self.errors[303222] = self.def_class(item=3032, level=1, tags=['maxspeed'],
             title=T_('Speed limit and type mismatch'),
             detail=T_(
 '''The speed limit in `maxspeed` is not consistent with the speed limit type in `maxspeed:type` or `source:maxspeed`.'''),
@@ -137,7 +137,7 @@ Always check `highway`, all other tags related to speed and verify on the ground
         # Error: maxspeed type without maxspeed
         if not maxspeed:
             if maxspeed_type or source_maxspeed:
-                err.append({'class': 1, 'text': T_('`{0}` without maxspeed',
+                err.append({'class': 303220, 'text': T_('`{0}` without maxspeed',
                                                    maxspeed_type if maxspeed_type else source_maxspeed)})
             return err
 
@@ -145,14 +145,14 @@ Always check `highway`, all other tags related to speed and verify on the ground
         if maxspeed.endswith(' km/h'):
             maxspeed = maxspeed[:-5]
         if not maxspeed.isdigit() and maxspeed != 'walk':
-            return {'class': 2, 'text': T_('Invalid maxspeed: `{0}`', maxspeed)}
+            return {'class': 309110, 'text': T_('Invalid maxspeed: `{0}`', maxspeed)}
 
         # Error: maxspeed suspiciously low, probably 'walk'; needs verification
         # except for speeds < 5 (covered in Number.py) and if signposted
         if maxspeed.isdigit():
             maxspeed_num = int(maxspeed)
             if (maxspeed_num > 4) and (maxspeed_num < 15) and (maxspeed_type != 'sign') and (source_maxspeed != 'sign'):
-                return {'class': 3, 'text': T_('Low maxspeed: `{0}`', maxspeed)}
+                return {'class': 309111, 'text': T_('Low maxspeed: `{0}`', maxspeed)}
 
         valid_type = None
         if maxspeed_type:
@@ -160,32 +160,32 @@ Always check `highway`, all other tags related to speed and verify on the ground
             if maxspeed_type in self.valid_maxspeed_types.keys():
                 valid_type = maxspeed_type
             else:
-                err.append({'class': 4,
+                err.append({'class': 309112,
                             'text': T_('Invalid maxspeed:type: `{0}`', maxspeed_type)})
             if source_maxspeed:
                 # Error: source:maxspeed equal to maxspeed:type
                 # Disabled for now to avoid excessive warnings; perform bulk cleanup first
                 if maxspeed_type == source_maxspeed:
-                    # err.append({'class': 5,
+                    # err.append({'class': 303221,
                     #            'text': T_('Duplicate speed limit type: `{0}`', maxspeed_type)})
                     pass
                 # Error: source:maxspeed contains different maxspeed type
                 elif source_maxspeed.startswith('AT:') or source_maxspeed in {'zone', 'sign', 'walk'}:
-                    err.append({'class': 5,
+                    err.append({'class': 303221,
                                 'text': T_('Conflicting speed limit types: `{0}`<>`{1}`', maxspeed_type, source_maxspeed)})
         elif source_maxspeed:
             # Error: source:maxspeed is invalid
             if source_maxspeed in self.valid_maxspeed_types.keys():
                 valid_type = source_maxspeed
             elif source_maxspeed.startswith('AT:') or source_maxspeed in {'zone', 'walk'}:
-                err.append({'class': 4,
+                err.append({'class': 309112,
                             'text': T_('Invalid source:maxspeed: `{0}`', source_maxspeed)})
 
         # Error: maxspeed type doesn't match maxspeed
         # except for types covered in TagFix_Maxspeed plugin and types without specific speed
         if valid_type and valid_type not in {'AT:motorway', 'AT:trunk', 'AT:rural', 'AT:urban'}:
             if self.valid_maxspeed_types.get(valid_type) and (self.valid_maxspeed_types.get(valid_type) != maxspeed):
-                err.append({'class': 6,
+                err.append({'class': 303222,
                             'text': T_('maxspeed and type mismatch: `{0}`<>`{1}`', maxspeed, valid_type)})
 
         return err

--- a/plugins/TagFix_Maxspeed_AT.py
+++ b/plugins/TagFix_Maxspeed_AT.py
@@ -142,6 +142,8 @@ Always check `highway`, all other tags related to speed and verify on the ground
             return err
 
         # Error: maxspeed not numeric or 'walk'
+        if maxspeed.endswith(' km/h'):
+            maxspeed = maxspeed[:-5]
         if not maxspeed.isdigit() and maxspeed != 'walk':
             return {'class': 2, 'text': T_('Invalid maxspeed: `{0}`', maxspeed)}
 
@@ -203,7 +205,7 @@ class Test(TestPluginCommon):
         # No error if valid
         assert not plugin.way(None, {'highway': 'primary'}, None)
 
-        assert not plugin.way(None, {'highway': 'primary', 'maxspeed': '100'}, None)
+        assert not plugin.way(None, {'highway': 'primary', 'maxspeed': '100 km/h'}, None)
 
         assert not plugin.way(None, {'highway': 'living_street', 'maxspeed': 'walk'}, None)
 
@@ -223,6 +225,8 @@ class Test(TestPluginCommon):
 
         # Error when maxspeed not numeric or walk
         self.check_err(plugin.way(None, {'highway': 'tertiary', 'maxspeed': 'fast'}, None))
+
+        self.check_err(plugin.way(None, {'highway': 'tertiary', 'maxspeed': '70 mph'}, None))
 
         # Error when maxspeed too low
         self.check_err(plugin.way(None, {'highway': 'residential', 'maxspeed': '5'}, None))

--- a/plugins/TagFix_Maxspeed_AT.py
+++ b/plugins/TagFix_Maxspeed_AT.py
@@ -58,7 +58,7 @@ class TagFix_Maxspeed_AT(Plugin):
 '''Set `maxspeed` and `maxspeed:type` or `source:maxspeed` (but not both) as appropriate.
 For a list of values, see table 'valid_maxspeed_types' in the source code below.'''),
             trap=T_(
-'''Do not just add a `maxspeed` value suitable for the type. The type may be incorrect too! 
+'''Do not just add a `maxspeed` value suitable for the type. The type may be incorrect too!
 Always check `highway`, all other tags related to speed and verify on the ground.'''),
             resource='https://wiki.openstreetmap.org/wiki/Key:maxspeed')
 
@@ -67,10 +67,10 @@ Always check `highway`, all other tags related to speed and verify on the ground
             detail=T_(
 '''The speed limit in `maxspeed` must be either numeric or `walk`. Do not specify a unit, km/h is the default.'''),
             fix=T_(
-'''Set `maxspeed` as appropriate and set speed limit type in `maxspeed:type` or `source:maxspeed` (but not both). 
+'''Set `maxspeed` as appropriate and set speed limit type in `maxspeed:type` or `source:maxspeed` (but not both).
 For a list of values, see table 'valid_maxspeed_types' in the source code below.'''),
             trap=T_(
-'''If a speed limit type (e.g. `AT:*`) is set in `maxspeed`, do not assume it's correct! 
+'''If a speed limit type (e.g. `AT:*`) is set in `maxspeed`, do not assume it's correct!
 Always check `highway`, all other tags related to speed and verify on the ground.'''),
             resource='https://wiki.openstreetmap.org/wiki/Key:maxspeed')
 
@@ -79,12 +79,12 @@ Always check `highway`, all other tags related to speed and verify on the ground
             detail=T_(
 '''The speed limit in `maxspeed` is very low and no type is given in `maxspeed:type` or `source:maxspeed`.'''),
             fix=T_(
-'''For pedestrian areas and living streets (except shared zones and school roads), walking speed is the default and no 
-speed limit or type should be set. If walking speed is prescribed on a sign, set `maxspeed=walk`, `maxspeed:type=sign` 
-and `traffic_sign=AT:54[text]` or `traffic_sign=AT:..,54[text]`. If a speed of 5 km/h is prescribed on a sign, 
+'''For pedestrian areas and living streets (except shared zones and school roads), walking speed is the default and no
+speed limit or type should be set. If walking speed is prescribed on a sign, set `maxspeed=walk`, `maxspeed:type=sign`
+and `traffic_sign=AT:54[text]` or `traffic_sign=AT:..,54[text]`. If a speed of 5 km/h is prescribed on a sign,
 set `maxspeed=5`, `maxspeed:type=sign`.'''),
             trap=T_(
-'''Do not assume any of the data present is correct!  
+'''Do not assume any of the data present is correct!
 Always check `highway`, all other tags related to speed and verify on the ground.'''),
             resource='https://wiki.openstreetmap.org/wiki/DE:Verkehrszeichen_in_Österreich')
 
@@ -93,23 +93,23 @@ Always check `highway`, all other tags related to speed and verify on the ground
             detail=T_(
 '''The speed limit type in `maxspeed:type` or `source:maxspeed` is not valid.'''),
             fix=T_(
-'''Set the appropriate speed limit type. For a list of values, 
+'''Set the appropriate speed limit type. For a list of values,
 see the table 'valid_maxspeed_types' in the source code below.'''),
             trap=T_(
-'''Do not assume any of the data present is correct!  
+'''Do not assume any of the data present is correct!
 Always check `highway`, all other tags related to speed and verify on the ground.'''),
             resource='https://wiki.openstreetmap.org/wiki/DE:Key:maxspeed:type')
 
         self.errors[5] = self.def_class(item=3032, level=2, tags=['maxspeed'],
             title=T_('Multiple speed limit types'),
             detail=T_(
-'''`maxspeed:type` and `source:maxspeed` are both set. This may cause confusion for mappers and data consumers, 
+'''`maxspeed:type` and `source:maxspeed` are both set. This may cause confusion for mappers and data consumers,
 especially if the values are different.'''),
             fix=T_(
-'''Set either `maxspeed:type` or `source:maxspeed` (but not both). For a list of values, 
+'''Set either `maxspeed:type` or `source:maxspeed` (but not both). For a list of values,
 see table 'valid_maxspeed_types' in the source code below.'''),
             trap=T_(
-'''Do not assume any of the data present is correct!  
+'''Do not assume any of the data present is correct!
 Always check `highway`, all other tags related to speed and verify on the ground.'''),
             resource='https://wiki.openstreetmap.org/wiki/DE:Key:maxspeed:type')
 
@@ -118,10 +118,10 @@ Always check `highway`, all other tags related to speed and verify on the ground
             detail=T_(
 '''The speed limit in `maxspeed` is not consistent with the speed limit type in `maxspeed:type` or `source:maxspeed`.'''),
             fix=T_(
-'''Set `maxspeed` and/or `maxspeed:type`/`source:maxspeed` (but not both) as appropriate. For a list of values, 
+'''Set `maxspeed` and/or `maxspeed:type`/`source:maxspeed` (but not both) as appropriate. For a list of values,
 see table 'valid_maxspeed_types' in the source code below.'''),
             trap=T_(
-'''Do not assume any of the data present is correct! 
+'''Do not assume any of the data present is correct!
 Always check `highway`, all other tags related to speed and verify on the ground.'''),
             resource='https://wiki.openstreetmap.org/wiki/DE:Key:maxspeed:type')
 
@@ -200,70 +200,55 @@ class Test(TestPluginCommon):
         plugin.init(None)
 
         # No error if not in Austria
-        assert not plugin.way(type('Obj', (object,), {'center_lat': 55, 'center_lon': 5})(),
-                              {'highway': 'residential', 'maxspeed_type': 'dont know', 'source:maxspeed': 'unknown'}, None)
+        assert not plugin.way(None, {'highway': 'residential', 'maxspeed_type': 'dont know',
+                              'source:maxspeed': 'unknown'}, None)
 
         # No error if in Austria but not a highway
-        assert not plugin.way(type('Obj', (object,), {'center_lat': 47.01, 'center_lon': 14})(),
-                              {'maxspeed_type': 'dont know', 'source:maxspeed': 'unknown'}, None)
+        assert not plugin.way(None, {'maxspeed_type': 'dont know', 'source:maxspeed': 'unknown'}, None)
 
         # No error if valid
-        assert not plugin.way(type('Obj', (object,), {'center_lat': 47.02, 'center_lon': 14})(),
-                              {'highway': 'primary'}, None)
-        
-        assert not plugin.way(type('Obj', (object,), {'center_lat': 47.03, 'center_lon': 14})(),
-                              {'highway': 'primary', 'maxspeed': '100'}, None)
+        assert not plugin.way(None, {'highway': 'primary'}, None)
 
-        assert not plugin.way(type('Obj', (object,), {'center_lat': 47.04, 'center_lon': 14})(),
-                              {'highway': 'living_street', 'maxspeed': 'walk'}, None)
-        
-        assert not plugin.way(type('Obj', (object,), {'center_lat': 47.05, 'center_lon': 14})(),
-                              {'highway': 'residential', 'maxspeed': '5', 'source:maxspeed': 'sign'}, None)
-        
-        assert not plugin.way(type('Obj', (object,), {'center_lat': 47.06, 'center_lon': 14})(),
-                              {'highway': 'secondary', 'maxspeed': '70', 'maxspeed:type': 'sign'}, None)
-        
-        assert not plugin.way(type('Obj', (object,), {'center_lat': 47.07, 'center_lon': 14})(),
-                              {'highway': 'tertiary', 'maxspeed': '50', 'source:maxspeed': 'AT:urban'}, None)
-        
-        assert not plugin.way(type('Obj', (object,), {'center_lat': 47.08, 'center_lon': 14})(),
-                              {'highway': 'unclassified', 'maxspeed': '100', 'maxspeed:type': 'AT:rural', 
-                                    'source:maxspeed': 'read it in the news'}, None)
-        
+        assert not plugin.way(None, {'highway': 'primary', 'maxspeed': '100'}, None)
+
+        assert not plugin.way(None, {'highway': 'living_street', 'maxspeed': 'walk'}, None)
+
+        assert not plugin.way(None, {'highway': 'residential', 'maxspeed': '5', 'source:maxspeed': 'sign'}, None)
+
+        assert not plugin.way(None, {'highway': 'secondary', 'maxspeed': '70', 'maxspeed:type': 'sign'}, None)
+
+        assert not plugin.way(None, {'highway': 'tertiary', 'maxspeed': '50', 'source:maxspeed': 'AT:urban'}, None)
+
+        assert not plugin.way(None, {'highway': 'unclassified', 'maxspeed': '100', 'maxspeed:type': 'AT:rural',
+                                               'source:maxspeed': 'read it in the news'}, None)
+
         # Error when maxspeed type without maxspeed
-        assert self.check_err(plugin.way(type('Obj', (object,), {'center_lat': 47.09, 'center_lon': 14})(),
-                              {'highway': 'secondary', 'maxspeed:type': 'sign'}, None))
+        assert self.check_err(plugin.way(None, {'highway': 'secondary', 'maxspeed:type': 'sign'}, None))
 
-        assert self.check_err(plugin.way(type('Obj', (object,), {'center_lat': 47.10, 'center_lon': 14})(),
-                              {'highway': 'secondary', 'source:maxspeed': 'sign'}, None))
+        assert self.check_err(plugin.way(None, {'highway': 'secondary', 'source:maxspeed': 'sign'}, None))
 
         # Error when maxspeed not numeric or walk
-        assert self.check_err(plugin.way(type('Obj', (object,), {'center_lat': 47.11, 'center_lon': 14})(),
-                              {'highway': 'tertiary', 'maxspeed': 'fast'}, None))
+        assert self.check_err(plugin.way(None, {'highway': 'tertiary', 'maxspeed': 'fast'}, None))
 
         # Error when maxspeed too low
-        assert self.check_err(plugin.way(type('Obj', (object,), {'center_lat': 47.12, 'center_lon': 14})(),
-                              {'highway': 'residential', 'maxspeed': '5'}, None))
+        assert self.check_err(plugin.way(None, {'highway': 'residential', 'maxspeed': '5'}, None))
 
         # Error when invalid speed limit type
-        assert self.check_err(plugin.way(type('Obj', (object,), {'center_lat': 47.13, 'center_lon': 14})(),
-                              {'highway': 'residential', 'maxspeed': '50', 'source:maxspeed': 'AT:city'}, None))
+        assert self.check_err(plugin.way(None, {'highway': 'residential', 'maxspeed': '50',
+                                                          'source:maxspeed': 'AT:city'}, None))
 
-        assert self.check_err(plugin.way(type('Obj', (object,), {'center_lat': 47.14, 'center_lon': 14})(),
-                              {'highway': 'secondary', 'maxspeed': '70', 'maxspeed:type': 'yes'}, None))
+        assert self.check_err(plugin.way(None, {'highway': 'secondary', 'maxspeed': '70', 'maxspeed:type': 'yes'}, None))
 
         # Error when speed limit type duplication
-        assert self.check_err(plugin.way(type('Obj', (object,), {'center_lat': 47.16, 'center_lon': 14})(),
-                              {'highway': 'unclassified', 'maxspeed': '100', 'maxspeed:type': 'AT:zone40', 
-                                    'source:maxspeed': 'AT:rural'}, None))
+        assert self.check_err(plugin.way(None, {'highway': 'unclassified', 'maxspeed': '100',
+                                                          'maxspeed:type': 'AT:zone40', 'source:maxspeed': 'AT:rural'}, None))
 
-        assert self.check_err(plugin.way(type('Obj', (object,), {'center_lat': 47.17, 'center_lon': 14})(),
-                              {'highway': 'unclassified', 'maxspeed': '100', 'maxspeed:type': 'AT:rural', 
-                                    'source:maxspeed': 'AT:urban'}, None))
+        assert self.check_err(plugin.way(None, {'highway': 'unclassified', 'maxspeed': '100',
+                                                          'maxspeed:type': 'AT:rural', 'source:maxspeed': 'AT:urban'}, None))
 
         # Error when speed and type mismatch
-        assert self.check_err(plugin.way(type('Obj', (object,), {'center_lat': 47.18, 'center_lon': 14})(),
-                              {'highway': 'secondary', 'maxspeed': '70', 'maxspeed:type': 'AT:city_limit30'}, None))
+        assert self.check_err(plugin.way(None, {'highway': 'secondary', 'maxspeed': '70',
+                                                          'maxspeed:type': 'AT:city_limit30'}, None))
 
-        assert self.check_err(plugin.way(type('Obj', (object,), {'center_lat': 47.19, 'center_lon': 14})(),
-                              {'highway': 'tertiary', 'maxspeed': '50', 'source:maxspeed': 'AT:rural'}, None))
+        assert self.check_err(plugin.way(None, {'highway': 'tertiary', 'maxspeed': '50',
+                                                          'source:maxspeed': 'AT:rural'}, None))

--- a/plugins/TagFix_Maxspeed_AT.py
+++ b/plugins/TagFix_Maxspeed_AT.py
@@ -173,7 +173,7 @@ Always check `highway`, all other tags related to speed and verify on the ground
             # Error: source:maxspeed is invalid
             if source_maxspeed in self.valid_maxspeed_types.keys():
                 valid_type = source_maxspeed
-            else:
+            elif source_maxspeed.startswith('AT:') or source_maxspeed in {'zone', 'walk'}:
                 err.append({'class': 4,
                             'text': T_('Invalid source:maxspeed: `{0}`', source_maxspeed)})
 


### PR DESCRIPTION
The plugin contains a number of tests focusing on `maxspeed`, `maxspeed:type` and `source:maxspeed` specific to Austria. It is by no means complete, but will do until further community decisions have been taken.

I've tested the logic locally, but have no Osmose dev environment. I need ids for 6 issue classes (currently numbered 1 to 6) and integration support. Test cases are provided, but have never run (I used a local test harness to feed data). I'd like to provide a German translation following successful integration.

#2503 