### PR TITLE
Support of composite circuits=2;1 in powerline osmosis

### DIFF
--- a/analysers/analyser_osmosis_powerline.py
+++ b/analysers/analyser_osmosis_powerline.py
@@ -28,17 +28,33 @@ from modules.Stablehash import stablehash64
 # Lines with no voltage get null voltage instead empty array
 sql01 = """
 CREATE TEMP TABLE power_lines_nodes AS
+WITH power_lines_norm AS (
+    SELECT
+        w.id,
+        w.nodes,
+        w.tags,
+        coalesce(w.tags->'circuits', '1') as circuits,
+        w.tags->'voltage' as voltage,
+        regexp_replace (w.tags->'voltage', ';', '_', 1,  greatest(1, char_length(w.tags->'circuits') - char_length(replace(w.tags->'circuits', ';', '')) - 1)) as voltage_norm
+    FROM ways w
+    WHERE
+        w.tags != ''::hstore AND
+        w.tags?'power' AND
+        w.tags->'power' IN ('line', 'minor_line', 'cable')
+)
+
 SELECT
     w.id as wid,
     unnest('{NULL}' || w.nodes[1:array_length(w.nodes, 1) - 1]) AS nid_prec,
     unnest(w.nodes) AS nid,
     unnest(w.nodes[2:]) AS nid_next,
     w.tags->'cables' AS cables,
-    coalesce((w.tags->'circuits')::integer, 1) AS circuits,
+    w.tags->'line' AS line,
+    t.circuits,
     coalesce(w.tags->'location', 'overhead') AS location,
-    voltages
+    t.voltages
 FROM
-    ways AS w
+    power_lines_norm AS w
     JOIN LATERAL (
         -- Creating a voltage list consistent with number of circuits by padding with the first voltage when necessary or limiting:
         -- Filling size is the difference between circuits (defaults to 1) and the number of voltages in the list
@@ -46,25 +62,44 @@ FROM
         -- circuits=2 + voltage=20000 => voltage={20000;20000} (filling with first value and no limiting)
         -- circuits=2 + voltage=20000;400 => voltage={20000;400} (no fill and no limiting)
         -- circuits=3 + voltage=20000;400 => voltage={20000;20000;400} (filling with first value and no limiting)
-        SELECT array_agg(lpad(v, 99, '0'))
-        FROM (SELECT
-            unnest(array_cat(
+        -- circuits=2;1 + voltage=400000;63000 => voltage={400000;400000;63000}
+        SELECT
+            count(*) as circuits,
+            array_agg(lpad(t3.v, 99, '0'))
+        FROM
+            -- circuits table
+            string_to_table(w.circuits, ';') WITH ORDINALITY AS t1(c, s),
+
+            -- voltages table
+            unnest(
+                CASE WHEN char_length(w.circuits) - char_length(replace(w.circuits, ';', '')) > 0 THEN
+                    array_cat(
+                        regexp_split_to_array(split_part(w.voltage_norm, '_', 1), '; *'),
+                        ARRAY[split_part(w.voltage_norm, '_', 2)]
+                    )
+                ELSE
+                    ARRAY[w.voltage]
+                END
+            ) WITH ORDINALITY AS t2(v, s)
+
+            JOIN LATERAL (SELECT
+                t1.c,
+                t1.s,
+                unnest(array_cat(
                 array_fill(
-                    split_part(w.tags->'voltage', ';', 1)::text, -- voltage1 in voltage1;voltage2
-                    ARRAY[greatest(0, coalesce((w.tags->'circuits')::integer, 1) - (1 + length(coalesce(w.tags->'voltage', '')) - length(replace(coalesce(w.tags->'voltage',''), ';', ''))))]
+                    split_part(t2.v, ';', t1.s::integer)::text, -- voltage1 in voltage1;voltage2
+                    ARRAY[greatest(0, (t1.c)::integer - (1 + length(coalesce(t2.v, '')) - length(replace(coalesce(t2.v,''), ';', ''))))]
                 ),
-                regexp_split_to_array(w.tags->'voltage', '; *'))
-            ) LIMIT coalesce((w.tags->'circuits')::integer, 1)
-        ) AS t(v)) AS t(voltages)
+                regexp_split_to_array(t2.v, '; *'))
+            ) LIMIT (t1.c)::integer
+            ) AS t3(c, s, v) ON t3.s=t2.s
+        ) AS t(circuits, voltages)
         ON TRUE
 WHERE
-    w.tags != ''::hstore AND
-    w.tags?'power' AND
-    w.tags->'power' IN ('line', 'minor_line', 'cable') AND
     w.tags?'voltage' AND
     (
         NOT w.tags?'circuits' OR
-        w.tags->'circuits' ~ '^[0-9]+$'
+        w.tags->'circuits' ~ '^[0-9;]+$'
     )
 
 UNION ALL
@@ -75,20 +110,16 @@ SELECT
     unnest(w.nodes) AS nid,
     unnest(w.nodes[2:]) AS nid_next,
     w.tags->'cables' AS cables,
+    w.tags->'line' AS line,
     coalesce((w.tags->'circuits')::integer, 1) AS circuits,
     coalesce(w.tags->'location', 'overhead') AS location,
     NULL AS voltages
 FROM
    ways AS w
 WHERE
-    w.tags != ''::hstore AND
-    w.tags?'power' AND
-    w.tags->'power' IN ('line', 'minor_line', 'cable') AND
-    (
-        NOT w.tags?'voltage' OR (
-            w.tags?'circuits' AND
-            w.tags->'circuits' !~ '^[0-9]+$'
-        )
+    NOT w.tags?'voltage' OR (
+        w.tags?'circuits' AND
+        w.tags->'circuits' !~ '^[0-9;]+$'
     )
 """
 
@@ -105,6 +136,7 @@ WITH topotuples as (
         n.nid,
         n.location,
         n.cables,
+        n.line,
         n.circuits,
         voltages
     FROM
@@ -120,6 +152,7 @@ WITH topotuples as (
         n.nid,
         n.location,
         n.cables,
+        n.line,
         n.circuits,
         voltages
     FROM
@@ -132,13 +165,14 @@ SELECT
     p.nid,
     p.tid,
     p.location,
+    p.line, 
     count(distinct p.wid) AS cw,
     sum(p.circuits::integer) AS circuits,
     regexp_split_to_array(string_agg(array_to_string(p.voltages, ';'), ';'), '; *') AS voltages
 FROM
     topotuples p
 GROUP BY
-    p.nid, p.tid, p.location
+    p.nid, p.tid, p.location, p.line
 HAVING
     bool_and(p.circuits IS NOT NULL)
 """
@@ -540,10 +574,16 @@ WITH vertices AS (
         string_agg(CASE WHEN e.location!='overhead' THEN e.circuits::varchar ELSE NULL END, '-' ORDER BY e.circuits desc) AS circuits_elsewhere
     FROM
         power_lines_topoedges e
+    JOIN nodes n ON
+        n.id=e.nid
     GROUP BY
         e.nid
     HAVING
-        count(*) > 1 AND sum(e.circuits) > 2
+        count(*) > 1 AND
+        sum(e.circuits) > 2 AND
+        NOT(COALESCE('busbar' = ANY(array_agg(e.line)),false)) AND
+        NOT(COALESCE('bay' = ANY(array_agg(e.line)),false)) AND
+        NOT(COALESCE('substation' = ANY(array_agg(array_append(akeys(n.tags), NULL))),false)) --Array_append to avoid empty arrays
 )
 
 SELECT
@@ -733,4 +773,5 @@ class Test(TestAnalyserOsmosis):
         self.check_err(cl="6", elems=[("node", "26191"), ("way", "2088")])
         self.check_err(cl="8", elems=[("node", "25956")])
         self.check_err(cl="8", elems=[("node", "26383")])
-        self.check_num_err(11)
+        self.check_err(cl="8", elems=[("node", "26982")])
+        self.check_num_err(12)

--- a/analysers/analyser_osmosis_powerline.py
+++ b/analysers/analyser_osmosis_powerline.py
@@ -165,7 +165,7 @@ SELECT
     p.nid,
     p.tid,
     p.location,
-    p.line, 
+    p.line,
     count(distinct p.wid) AS cw,
     sum(p.circuits::integer) AS circuits,
     regexp_split_to_array(string_agg(array_to_string(p.voltages, ';'), ';'), '; *') AS voltages

--- a/tests/osmosis_powerline.test.osm
+++ b/tests/osmosis_powerline.test.osm
@@ -194,6 +194,51 @@
     <tag k='note' v='Should raise class 1 warning isolated power tower' />
     <tag k='power' v='tower' />
   </node>
+  <node id='26980' timestamp='2025-04-24T15:00:00Z' version='1' lat='46.19101084274' lon='4.475601043'>
+    <tag k='line_management' v='transition' />
+    <tag k='location:transition' v='yes' />
+    <tag k='power' v='tower' />
+  </node>
+  <node id='26981' timestamp='2025-04-24T15:00:00Z' version='1' lat='46.1917632542' lon='4.47749077471'>
+    <tag k='power' v='tower' />
+  </node>
+  <node id='26982' timestamp='2025-04-24T15:00:00Z' version='1' lat='46.19086548934' lon='4.47978809561'>
+    <tag k='power' v='tower' />
+  </node>
+  <node id='26983' timestamp='2025-04-24T15:00:00Z' version='1' lat='46.1916008026' lon='4.48173958326'>
+    <tag k='line_management' v='transition' />
+    <tag k='location:transition' v='yes' />
+    <tag k='power' v='tower' />
+  </node>
+  <node id='26984' timestamp='2025-04-24T15:00:00Z' version='1' lat='46.19018146391' lon='4.48178899418'>
+    <tag k='line_management' v='termination' />
+    <tag k='power' v='tower' />
+  </node>
+  <way id='-598' timestamp='2025-04-24T15:00:00Z' version='1'>
+    <nd ref='26980' />
+    <nd ref='26981' />
+    <nd ref='26982' />
+    <tag k='cables' v='9' />
+    <tag k='circuits' v='2;1' />
+    <tag k='power' v='line' />
+    <tag k='voltage' v='400000;225000' />
+  </way>
+  <way id='-602' timestamp='2025-04-24T15:00:00Z' version='1'>
+    <nd ref='26982' />
+    <nd ref='26983' />
+    <tag k='cables' v='6' />
+    <tag k='circuits' v='2' />
+    <tag k='power' v='line' />
+    <tag k='voltage' v='400000' />
+  </way>
+  <way id='-604' timestamp='2025-04-24T15:00:00Z' version='1'>
+    <nd ref='26982' />
+    <nd ref='26984' />
+    <tag k='cables' v='3' />
+    <tag k='circuits' v='1' />
+    <tag k='power' v='line' />
+    <tag k='voltage' v='225000' />
+  </way>
   <way id='1343' timestamp='2025-04-24T15:00:00Z' version='1'>
     <nd ref='26925' />
     <nd ref='26924' />


### PR DESCRIPTION
This PR brings the following changes on osmosis_powerline analyser:
* Fix #2528 with support of composite circuits values like circuits=2;1. It digest the list and compute the appropriate voltages
* Fix #2526 By disabling line_management suggestion on `bay` and `busbar` ways and `substation=*` nodes.

Tests has been updated with composite circuits supports

It is expected to lower warnings like
* https://osmose.openstreetmap.fr/fr/issue/e16a9935-82d5-40ea-120b-a37013a11fb2
* https://osmose.openstreetmap.fr/fr/issue/fb602bc8-2dbb-4006-9ea4-59d001838fa3