### PR TITLE
Fix CI and docker - remove hidden char

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
 
     services:
       postgres:
-        image: postgis/postgis:16-3.5-alpine⁠
+        image: postgis/postgis:16-3.5-alpine
         env:
           POSTGRES_PASSWORD: -osmose-
 
@@ -145,7 +145,7 @@ jobs:
 
     services:
       postgres:
-        image: postgis/postgis:16-3.5-alpine⁠
+        image: postgis/postgis:16-3.5-alpine
         env:
           POSTGRES_PASSWORD: -osmose-
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
 services:
   postgis:
     shm_size: 1g
-    image: postgis/postgis:16-3.5-alpine⁠
+    image: postgis/postgis:16-3.5-alpine
     volumes:
       - type: bind
         source: ./postgis-init.sh


### PR DESCRIPTION
Remove an hidden char in the CI and docker-compose files.

This changes cause a test to end up in error:
`analysers.analyser_osmosis_highway_deadend.Test testMethod=test_classes`

But the outcome looks right to me, no oneway looks inaccessible in the test case