### PR TITLE
test: Fix comparison of lat/lon

### DIFF
--- a/analysers/Analyser.py
+++ b/analysers/Analyser.py
@@ -313,6 +313,34 @@ class TestAnalyser(unittest.TestCase):
         if name_analyser == "analyser" and "delete" in a["analysers"][name_analyser]:
             del a["analysers"][name_analyser]["delete"]
 
+    @staticmethod
+    def shorten_coordinates_list(a):
+        # Make sure that lat/lon are comparable by round them to N decimals
+        for k in range(len(a)):
+            if hasattr(a[k], 'items'):
+                a[k] = TestAnalyser.shorten_coordinates(a[k])
+            elif isinstance(a[k], list):
+                a[k] = TestAnalyser.shorten_coordinates_list(a[k])
+        return a
+
+    @staticmethod
+    def shorten_coordinates(a):
+        # Make sure that lat/lon are comparable by round them to N decimals
+        for k in a.keys():
+            if k == "@lat" or k == "@lon":
+                if isinstance(a[k], float):
+                    a[k] = round(a[k], 13)
+                elif isinstance(a[k], str):
+                    try:
+                        a[k] = str(round(float(a[k]), 13))
+                    except:
+                        pass
+            elif hasattr(a[k], 'items'):
+                a[k] = TestAnalyser.shorten_coordinates(a[k])
+            elif isinstance(a[k], list):
+                a[k] = TestAnalyser.shorten_coordinates_list(a[k])
+        return a
+
     def compare_results(self, orig_xml=None, checked_xml=None, convert_checked_to_normal=False):
         if orig_xml is None:
             raise  # TODO
@@ -332,6 +360,9 @@ class TestAnalyser(unittest.TestCase):
 
         TestAnalyser.remove_non_checked_entries(a)
         TestAnalyser.remove_non_checked_entries(b)
+
+        a = TestAnalyser.shorten_coordinates(a)
+        b = TestAnalyser.shorten_coordinates(b)
 
         if a != b:
             s = TestAnalyser.compare_dict(a, b)
@@ -434,6 +465,67 @@ class Test(unittest.TestCase):
         self.assertEqual(a.compare_dict({1:{3:4}, 2:2}, {1:{4:5}, 2:2}), u"key '3' is missing from b [.1]")
         self.assertEqual(a.compare_dict({1:{   }, 2:2}, {1:{3:4}, 2:2}), u"key '3' is missing from a [.1]")
         self.assertEqual(a.compare_dict({1:{3:4}, 2:2}, {1:{   }, 2:2}), u"key '3' is missing from b [.1]")
+
+    def test_coordinates(self):
+        a = TestAnalyser
+        self.assertEqual(a.compare_dict({"@lat":43.9533100018163, "@lon":10}, {"@lat":43.9533100018163, "@lon":10}), u"")
+
+        t0 = a.shorten_coordinates({"@lat": 43.9533100018163, "@lon": 10})
+        t1 = a.shorten_coordinates({"@lat": 43.9533100018163, "@lon": 10})
+        self.assertEqual(a.compare_dict(t0, t1), u"")
+
+        t0 = a.shorten_coordinates({"@lat": 43.9533100018163,  "@lon": 10})
+        t1 = a.shorten_coordinates({"@lat": 43.95331000181634, "@lon": 10})
+        self.assertEqual(a.compare_dict(t0, t1), u"")
+
+        t0 = a.shorten_coordinates({"@lat": 43.9533100018163,   "@lon": 10})
+        t1 = a.shorten_coordinates({"@lat": 43.953310001816334, "@lon": 10})
+        self.assertEqual(a.compare_dict(t0, t1), u"")
+
+        t0 = a.shorten_coordinates({1: {"@lat": 43.9533100018163,  "@lon": 10}})
+        t1 = a.shorten_coordinates({1: {"@lat": 43.95331000181634, "@lon": 10}})
+        self.assertEqual(a.compare_dict(t0, t1), u"")
+
+        t0 = a.shorten_coordinates({1: [{"@lat": 43.9533100018163,  "@lon": 10},]})
+        t1 = a.shorten_coordinates({1: [{"@lat": 43.95331000181634, "@lon": 10},]})
+        self.assertEqual(a.compare_dict(t0, t1), u"")
+
+        t0 = a.shorten_coordinates({"@lat": "43.9533100018163",   "@lon": 10})
+        t1 = a.shorten_coordinates({"@lat": "43.953310001816334", "@lon": 10})
+        self.assertEqual(a.compare_dict(t0, t1), u"")
+
+        t0 = a.shorten_coordinates({"@lat": 43.953310001816,   "@lon": 10})
+        t1 = a.shorten_coordinates({"@lat": 43.95331000181634, "@lon": 10})
+        self.assertEqual(a.compare_dict(t0, t1), u"key '@lat' is different: '43.953310001816' != '43.9533100018163' []")
+
+        t0 = a.shorten_coordinates({"@lat": 43.95331000181634, "@lon": 43.953310001816})
+        t1 = a.shorten_coordinates({"@lat": 43.95331000181634, "@lon": 43.95331000181634})
+        self.assertEqual(a.compare_dict(t0, t1), u"key '@lon' is different: '43.953310001816' != '43.9533100018163' []")
+
+        t0 = a.shorten_coordinates({"@lat": 43.95331000181634, "@lon": 45.95331000181634})
+        t1 = a.shorten_coordinates({"@lat": 43.95331000181634, "@lon": 43.95331000181634})
+        self.assertEqual(a.compare_dict(t0, t1), u"key '@lon' is different: '45.9533100018163' != '43.9533100018163' []")
+
+        t0 = a.shorten_coordinates({1: {"@lat": 43.953310001816,   "@lon": 10}})
+        t1 = a.shorten_coordinates({1: {"@lat": 43.95331000181634, "@lon": 10}})
+        self.assertEqual(a.compare_dict(t0, t1), u"key '@lat' is different: '43.953310001816' != '43.9533100018163' [.1]")
+
+        t0 = a.shorten_coordinates({1: [{"@lat": 43.953310001816,   "@lon": 10},]})
+        t1 = a.shorten_coordinates({1: [{"@lat": 43.95331000181634, "@lon": 10},]})
+        self.assertEqual(a.compare_dict(t0, t1), u"key '@lat' is different: '43.953310001816' != '43.9533100018163' [.1.0]")
+
+        t0 = a.shorten_coordinates({1: [{"@lat": "43.953310001816",   "@lon": 10},]})
+        t1 = a.shorten_coordinates({1: [{"@lat": "43.95331000181634", "@lon": 10},]})
+        self.assertEqual(a.compare_dict(t0, t1), u"key '@lat' is different: '43.953310001816' != '43.9533100018163' [.1.0]")
+
+        # only @lat/@lon should be modified
+        t0 = a.shorten_coordinates({"other": 43.9533100018163, "@lon": 10})
+        t1 = a.shorten_coordinates({"other": 43.9533100018163, "@lon": 10})
+        self.assertEqual(a.compare_dict(t0, t1), u"")
+
+        t0 = a.shorten_coordinates({"other": 43.9533100018163,  "@lon": 10})
+        t1 = a.shorten_coordinates({"other": 43.95331000181634, "@lon": 10})
+        self.assertEqual(a.compare_dict(t0, t1), u"key 'other' is different: '43.9533100018163' != '43.95331000181634' []")
 
     def test_merge_doc(self):
         self.assertEqual(Analyser.merge_doc({'en': 'a'}, {'en': 'b'}), {'en': 'a\n\nb'})


### PR DESCRIPTION
Floating-point values must be rounded if we want to compare them, as there is no guarantee on the final digits between postgis and python.