### PR TITLE
Restrict osmosis_powerline 7040 class 8 to 50 kV and above

### DIFF
--- a/tests/osmosis_powerline.test.osm
+++ b/tests/osmosis_powerline.test.osm
@@ -17,8 +17,8 @@
     <tag k='location' v='underground' />
     <tag k='power' v='pole' />
   </node>
-  <node id='25880' timestamp='2025-04-24T15:00:00Z' version='1' lat='46.19018976738' lon='4.47730911825'>
-    <tag k='line_management' v='branch' />
+  <node id='25880' action='modify' timestamp='2025-04-24T15:00:00Z' version='1' lat='46.19018976738' lon='4.47730911825'>
+    <tag k='note' v='Should NOT raise class 8 warning line_management suggestion: below 50 kV' />
     <tag k='power' v='pole' />
   </node>
   <node id='25881' timestamp='2025-04-24T15:00:00Z' version='1' lat='46.19025116596' lon='4.47738773173'>


### PR DESCRIPTION
This PR follows up #2548 and propose to filter item 7040/class 8 line_management suggestion to nodes with 50 kV and above voltages.  

It is intended to significantly lower the amount of warning raised by this analysis