### PR TITLE
AU: allow CSIRO, ANZAC uppercase

### DIFF
--- a/plugins/Name_UpperCase.py
+++ b/plugins/Name_UpperCase.py
@@ -27,6 +27,7 @@ from plugins.modules.name_suggestion_index import whitelist_from_nsi
 # Whitelist of allowed capitals by country code
 UpperCase_WhiteList = {
     "FR": ["CNFPT", "COSEC", "EHPAD", "MEDEF", "URSSAF"],
+    "AU": ["ANZAC", "CSIRO"],
 }
 
 class Name_UpperCase(Plugin):


### PR DESCRIPTION
fixes #2583

warning: untested