### PR TITLE
Update TagFix_BadValue.py - exclude crossing=separate

### DIFF
--- a/plugins/TagFix_BadValue.py
+++ b/plugins/TagFix_BadValue.py
@@ -95,7 +95,7 @@ However, this should probably still conform to the typical format used for value
         self.allow_closed = { "area": ( "yes", "no", ),
                             "backrest": ( "yes", "no", ),
                             "conveying": ( "yes", "forward", "backward", "no", "reversible", ),
-                            "crossing": ( "traffic_signals", "uncontrolled", "unmarked", "no", "marked", "zebra", "informal", ),
+                            "crossing": ( "traffic_signals", "uncontrolled", "unmarked", "no", "marked", "zebra", "informal", "separate", ),
                             "lane_markings": ( "yes", "no", ),
                             "narrow": ( "yes", "no", ),
                             "oneway": ( "yes", "no", "1", "-1", "reversible", "alternating"),


### PR DESCRIPTION
Add recently documented tag crossing=separate to list in allow_closed

https://wiki.openstreetmap.org/wiki/Tag:crossing%3Dseparate