### PR TITLE
Enable merge_power_pole_FR_spec_enedis in France, Aveyron

### DIFF
--- a/osmose_config.py
+++ b/osmose_config.py
@@ -456,7 +456,9 @@ france_departement("lorraine/vosges", 7384, "FR-88")
 france_departement("midi_pyrenees/ariege", 7439, "FR-09", include=[
     'merge_power_pole_FR_spec_enedis'
 ])
-france_departement("midi_pyrenees/aveyron", 7451, "FR-12")
+france_departement("midi_pyrenees/aveyron", 7451, "FR-12", include=[
+    'merge_power_pole_FR_spec_enedis'
+])
 france_departement("midi_pyrenees/haute_garonne", 7413, "FR-31", include=[
     'merge_power_pole_FR_spec_enedis',
     # Toulouse


### PR DESCRIPTION
Hello

I would like to enable _merge_power_pole_FR_spec_enedis_ on Aveyron in France.

We've mapped ~51 000 poles there and the open data files exposes 17 500 rows for this area, so the amount of warnings will not be significant while allowing to find some important differences.

It's a test to see how it goes on well mapped areas. Several others could lead to the same results:
- Loire-Atlantique (60 000 osm vs 39 500 enedis)
- Jura (25 200 osm vs 9 000 enedis)
- Doubs (23 600 osm vs 14 000 enedis)